### PR TITLE
chore: update deprecation.since to be of `date` format

### DIFF
--- a/schemas/components/deprecation.json
+++ b/schemas/components/deprecation.json
@@ -11,7 +11,8 @@
         },
         "since": {
             "type": "string",
-            "description": "The version number when the deprecation was made."
+            "description": "The date when the deprecation was made.",
+            "format": "date"
         }
     }
 }


### PR DESCRIPTION
`date` format in the JSON schema spec refers to `full-date` per RFC3339
(https://www.rfc-editor.org/rfc/rfc3339.txt) - `YYYY-MM-DD`.
